### PR TITLE
添加自动化构建流程,并更新readme文件

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,80 @@
+name: Release CI
+on: push
+jobs:
+  x64_build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+      
+    - name: Run msbuild
+      run: msbuild -p:configuration=release -p:platform=x64 -p:platformToolset=v142
+      
+    - name: Get current time
+      uses: 1466587594/current-time@v1
+      id: current-time
+      with:
+        format: YYYYMMDD_HHmmss
+        utcOffset: "+08:00"
+      
+    - name : Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: x64_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
+        path: x64/Release/TrafficMonitor.exe
+
+  x86_build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+      
+    - name: Run msbuild
+      run: msbuild -p:configuration=release -p:platform=x86 -p:platformToolset=v142
+      
+    - name: Get current time
+      uses: 1466587594/current-time@v1
+      id: current-time
+      with:
+        format: YYYYMMDD_HHmmss
+        utcOffset: "+08:00"
+      
+    - name : Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: x86_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
+        path: Release/TrafficMonitor.exe
+
+  winXP_build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+      
+    - name: Run msbuild
+      run: |
+        set ExternalCompilerOptions=/DCOMPILE_FOR_WINXP
+        msbuild -p:configuration=release -p:platform=x86 -p:platformToolset=v140_xp
+      shell: cmd
+      
+    - name: Get current time
+      uses: 1466587594/current-time@v1
+      id: current-time
+      with:
+        format: YYYYMMDD_HHmmss
+        utcOffset: "+08:00"
+      
+    - name : Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: winXP_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
+        path: Release/TrafficMonitor.exe

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 **简体中文 | [繁體中文](https://github.com/zhongyang219/TrafficMonitor/blob/master/README_zh-tw.md) | [English](https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md)**<br>
 [![Badge](https://img.shields.io/badge/link-996.icu-%23FF4D5B.svg?style=flat-square)](https://996.icu/#/en_US)
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg?style=flat-square)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/zhongyang219/TrafficMonitor/Release%20CI?label=Release%20CI&logo=github&style=flat-square)](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")
+[![GitHub release](https://img.shields.io/github/release/zhongyang219/TrafficMonitor.svg?style=flat-square)](https://github.com/zhongyang219/TrafficMonitor/releases/latest)
 # TrafficMonitor 简介
 Traffic Monitor是一款用于Windows平台的网速监控悬浮窗软件，可以显示当前网速、CPU及内存利用率，支持嵌入到任务栏显示，支持更换皮肤、历史流量统计等功能。<br>
 # 相关链接：<br>
 请[点击此处](https://github.com/zhongyang219/TrafficMonitor/releases)下载TrafficMonitor的最新版本。<br>
 备用链接：[百度网盘下载](https://pan.baidu.com/s/1c1LkPQ4)<br>
-如果遇到问题，请[点击此处](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help.md)。
+如果遇到问题，请[点击此处](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help.md)。<br>
+
+请[点击此处](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")下载TrafficMonitor的预发行构建版本。
 
 # 主要特性
 * 显示当前实现网络传输速率、CPU和内存占用率<br>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Traffic Monitor是一款用于Windows平台的网速监控悬浮窗软件，可�
 备用链接：[百度网盘下载](https://pan.baidu.com/s/1c1LkPQ4)<br>
 如果遇到问题，请[点击此处](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help.md)。<br>
 
-请[点击此处](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")下载TrafficMonitor的预发行构建版本。
+你也可以[点击此处](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")下载TrafficMonitor的预发行构建版本。
 
 # 主要特性
 * 显示当前实现网络传输速率、CPU和内存占用率<br>

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -10,7 +10,7 @@ Please [click here](https://github.com/zhongyang219/TrafficMonitor/releases) to 
 Alternate link: Download from [Baidu Netdisk](https://pan.baidu.com/s/1c1LkPQ4)<br>
 If you encounter any problems, please [click here](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help_en-us.md).<br>
 
-Please [click here](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI") to download the pre-release build version of TrafficMonitor.
+You can also [click here](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI") to download the pre-release build version of TrafficMonitor.
 
 # Main Features
 * Displays the current network transfer speed, CPU and memory usage.<br>

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -1,12 +1,16 @@
 **[简体中文](https://github.com/zhongyang219/TrafficMonitor/blob/master/README.md) | [繁體中文](https://github.com/zhongyang219/TrafficMonitor/blob/master/README_zh-tw.md) | English**<br>
 [![Badge](https://img.shields.io/badge/link-996.icu-%23FF4D5B.svg?style=flat-square)](https://996.icu/#/en_US)
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg?style=flat-square)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/zhongyang219/TrafficMonitor/Release%20CI?label=Release%20CI&logo=github&style=flat-square)](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")
+[![GitHub release](https://img.shields.io/github/release/zhongyang219/TrafficMonitor.svg?style=flat-square)](https://github.com/zhongyang219/TrafficMonitor/releases/latest)
 # TrafficMonitor Introduction
 TrafficMonitor is a network monitoring suspension window software in Windows platform. It can display the current network speed, CPU and memory usage. It also support the functions of display in the taskbar, change skin and historical traffic statistics. <br>
 # Related Links<br>
 Please [click here](https://github.com/zhongyang219/TrafficMonitor/releases) to download the latest version of TrafficMonitor.<br>
 Alternate link: Download from [Baidu Netdisk](https://pan.baidu.com/s/1c1LkPQ4)<br>
-If you encounter any problems, please [click here](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help_en-us.md).
+If you encounter any problems, please [click here](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help_en-us.md).<br>
+
+Please [click here](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI") to download the pre-release build version of TrafficMonitor.
 
 # Main Features
 * Displays the current network transfer speed, CPU and memory usage.<br>

--- a/README_zh-tw.md
+++ b/README_zh-tw.md
@@ -10,7 +10,7 @@ Traffic Monitor是一款用於Windows平台的網速監控懸浮窗軟體，可�
 備用連結：[百度網盤下載](https://pan.baidu.com/s/1c1LkPQ4)<br>
 如果遇到問題，請[點選此處](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help.md)。<br>
 
-請[點擊此處](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")下載TrafficMonitor的預發行構建版本。
+你也可以[點擊此處](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")下載TrafficMonitor的預發行構建版本。
 
 # 主要特性
 * 顯示目前實現網路傳輸速率、CPU和記憶體使用率<br>

--- a/README_zh-tw.md
+++ b/README_zh-tw.md
@@ -1,12 +1,16 @@
 **[簡體中文](https://github.com/zhongyang219/TrafficMonitor/blob/master/README.md) | 繁體中文 | [English](https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md)**<br>
 [![Badge](https://img.shields.io/badge/link-996.icu-%23FF4D5B.svg?style=flat-square)](https://996.icu/#/en_US)
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg?style=flat-square)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/zhongyang219/TrafficMonitor/Release%20CI?label=Release%20CI&logo=github&style=flat-square)](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")
+[![GitHub release](https://img.shields.io/github/release/zhongyang219/TrafficMonitor.svg?style=flat-square)](https://github.com/zhongyang219/TrafficMonitor/releases/latest)
 # TrafficMonitor 簡介
 Traffic Monitor是一款用於Windows平台的網速監控懸浮窗軟體，可以顯示目前網路速度、CPU及記憶體使用率，支援嵌入到工作列顯示，支援更換面板、歷史流量統計等功能。<br>
 # 相關連結：<br>
 請[點選此處](https://github.com/zhongyang219/TrafficMonitor/releases)下載TrafficMonitor的最新版本。<br>
 備用連結：[百度網盤下載](https://pan.baidu.com/s/1c1LkPQ4)<br>
-如果遇到問題，請[點選此處](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help.md)。
+如果遇到問題，請[點選此處](https://github.com/zhongyang219/TrafficMonitor/blob/master/Help.md)。<br>
+
+請[點擊此處](https://github.com/zhongyang219/TrafficMonitor/actions?query=workflow:"Release+CI")下載TrafficMonitor的預發行構建版本。
 
 # 主要特性
 * 顯示目前實現網路傳輸速率、CPU和記憶體使用率<br>

--- a/TrafficMonitor/TrafficMonitor.vcxproj
+++ b/TrafficMonitor/TrafficMonitor.vcxproj
@@ -75,15 +75,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <ExcludePath />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <ExcludePath />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <ExcludePath />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <ExcludePath />
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -139,6 +143,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalOptions>$(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
添加github actions自动化构建文件,从而自动构建最新的提交
![image](https://user-images.githubusercontent.com/13366013/75739588-3d8a8600-5d40-11ea-84b4-50c549c64aa8.png)

为此需要指定工程文件排除项为空 ```<ExcludePath />``` ,否则无法编译mfc项目

目前github actions使用的windows-latest版本,v141构建工具存在问题,无法编译mfc项目,因此对于x64和x86构建,指定了```-p:platformToolset=v142```以采用v142构建工具,对于windowsXP构建,指定了```-p:platformToolset=v140_xp```和```COMPILE_FOR_WINXP```,下为XP运行效果

![image](https://user-images.githubusercontent.com/13366013/75739739-ab36b200-5d40-11ea-821d-569a76ac8c69.png)

更新Readme文件以引导下载最新的自动构建版本,并提示构建状态

![image](https://user-images.githubusercontent.com/13366013/75739989-6eb78600-5d41-11ea-8527-0af3e37a5a51.png)
