### PR TITLE
解决预构建版本由于未添加dll，导致无法使用的问题

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         utcOffset: "+08:00"
       
     - name : Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: x64_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
         path: |
@@ -48,7 +48,7 @@ jobs:
         utcOffset: "+08:00"
       
     - name : Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: x86_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
         path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: x64_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
-        path: Bin/x64/Release/TrafficMonitor.exe
+        path: |
+          Bin/x64/Release/TrafficMonitor.exe
+          Bin/x64/Release/*.dll
 
   x86_build:
     runs-on: windows-latest
@@ -49,7 +51,9 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: x86_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
-        path: Bin/Release/TrafficMonitor.exe
+        path: |
+          Bin/Release/TrafficMonitor.exe
+          Bin/Release/*.dll
 
   # winXP_build:
     # runs-on: windows-latest


### PR DESCRIPTION
多路径上传是upload-artifact@v2的特性，更新版本即可