### PR TITLE
增加对Win11的适配

### DIFF
--- a/TrafficMonitor/CommonData.h
+++ b/TrafficMonitor/CommonData.h
@@ -303,6 +303,7 @@ struct TaskBarSettingData : public PublicSettingData
     bool horizontal_arrange{ true };    //水平排列
     bool show_status_bar{ true };       //显示 CPU/内存的状态条
     bool tbar_wnd_on_left{ false };     //如果为true，则任务栏窗口显示在任务栏的左侧（或上方）
+    bool tbar_wnd_snap{ false };     	//如果为true，则在Win11中任务栏窗口贴靠中间任务栏，否则靠近边缘
     bool cm_graph_type{ false };        //如果为false，默认原样式，柱状图显示占用率，如为true，滚动显示占用率
 };
 

--- a/TrafficMonitor/TaskBarDlg.h
+++ b/TrafficMonitor/TaskBarDlg.h
@@ -39,6 +39,7 @@ protected:
 
 	HWND m_hTaskbar;	//任务栏窗口句柄
 	HWND m_hBar;		//任务栏窗口二级容器的句柄
+	HWND m_hBarSnap;	//任务栏窗口二级容器(Win11)的句柄
 	HWND m_hMin;		//最小化窗口的句柄
 	CRect m_rcBar;		//初始状态时任务栏窗口的矩形区域
 	CRect m_rcMin;		//初始状态时最小化窗口的矩形区域

--- a/TrafficMonitor/TaskBarSettingsDlg.cpp
+++ b/TrafficMonitor/TaskBarSettingsDlg.cpp
@@ -417,6 +417,9 @@ void CTaskBarSettingsDlg::OnBnClickedTaskbarWndOnLeftCheck()
 {
     // TODO: 在此添加控件通知处理程序代码
     m_data.tbar_wnd_on_left = (((CButton*)GetDlgItem(IDC_TASKBAR_WND_ON_LEFT_CHECK))->GetCheck() != 0);
+	if (m_win_version.IsWindows11OrLater()) {
+        m_data.tbar_wnd_snap = (MessageBoxW(_T("将窗口贴靠到状态栏吗？\n不贴靠将置于底栏两端。"), _T("Windows11 兼容设置"), MB_YESNO | MB_ICONQUESTION) == 6); // 本地化暂缺。考虑增加一个设置项代替弹窗
+    }
 }
 
 

--- a/TrafficMonitor/TaskBarSettingsDlg.h
+++ b/TrafficMonitor/TaskBarSettingsDlg.h
@@ -19,6 +19,8 @@ public:
     //选项设置数据
     TaskBarSettingData m_data;
 
+	CWinVersionHelper m_win_version;        //当前Windows的版本
+
     // 对话框数据
 #ifdef AFX_DESIGN_TIME
     enum { IDD = IDD_TASKBAR_SETTINGS_DIALOG };

--- a/TrafficMonitor/TrafficMonitor.cpp
+++ b/TrafficMonitor/TrafficMonitor.cpp
@@ -211,6 +211,7 @@ void CTrafficMonitorApp::LoadConfig()
 
     m_taskbar_data.tbar_wnd_on_left = ini.GetBool(_T("task_bar"), _T("task_bar_wnd_on_left"), false);
     m_taskbar_data.speed_short_mode = ini.GetBool(_T("task_bar"), _T("task_bar_speed_short_mode"), false);
+    m_taskbar_data.tbar_wnd_snap = ini.GetBool(_T("task_bar"), _T("task_bar_wnd_snap"), false);
     m_taskbar_data.unit_byte = ini.GetBool(_T("task_bar"), _T("unit_byte"), true);
     m_taskbar_data.speed_unit = static_cast<SpeedUnit>(ini.GetInt(_T("task_bar"), _T("task_bar_speed_unit"), 0));
     m_taskbar_data.hide_unit = ini.GetBool(_T("task_bar"), _T("task_bar_hide_unit"), false);
@@ -355,6 +356,7 @@ void CTrafficMonitorApp::SaveConfig()
     ini.WriteString(_T("task_bar"), _T("main_board_temp_string"), m_taskbar_data.disp_str.Get(TDI_MAIN_BOARD_TEMP));
 
     ini.WriteBool(L"task_bar", L"task_bar_wnd_on_left", m_taskbar_data.tbar_wnd_on_left);
+    ini.WriteBool(L"task_bar", L"task_bar_wnd_snap", m_taskbar_data.tbar_wnd_snap);
     ini.WriteBool(L"task_bar", L"task_bar_speed_short_mode", m_taskbar_data.speed_short_mode);
     ini.WriteBool(L"task_bar", L"unit_byte", m_taskbar_data.unit_byte);
     ini.WriteInt(L"task_bar", L"task_bar_speed_unit", static_cast<int>(m_taskbar_data.speed_unit));

--- a/TrafficMonitor/WinVersionHelper.cpp
+++ b/TrafficMonitor/WinVersionHelper.cpp
@@ -31,6 +31,17 @@ CWinVersionHelper::~CWinVersionHelper()
 {
 }
 
+bool CWinVersionHelper::IsWindows11OrLater() const
+{
+	if (m_major_version > 10)
+		return true;
+	else if (m_major_version == 10 && m_minor_version > 0)
+		return true;
+	else if (m_major_version == 10 && m_minor_version == 0 && m_build_number >= 21996)
+		return true;
+	else return false;
+}
+
 bool CWinVersionHelper::IsWindows10FallCreatorOrLater() const
 {
 	if (m_major_version > 10)

--- a/TrafficMonitor/WinVersionHelper.h
+++ b/TrafficMonitor/WinVersionHelper.h
@@ -5,6 +5,7 @@ public:
 	CWinVersionHelper();
 	~CWinVersionHelper();
 
+	bool IsWindows11OrLater() const;			//判断当前Windows版本是否为Win11或更新的版本
 	bool IsWindows10FallCreatorOrLater() const;		//判断当前Windows版本是否为Win10秋季创意者更新或更新的版本
 	bool IsWindows7() const;					//判断Windows版本是否为Windows7
 	bool IsWindows8Or8point1() const;			//判断Windows版本是否为Windows8或Windows8.1


### PR DESCRIPTION
判断系统版本为Win11（Build 21996 以上）时，适配新的任务栏。
对于居中的任务栏，支持四种对齐方式（最左，贴靠任务栏左，贴靠任务栏右，最右），暂时使用弹窗调整。
是否贴靠使用 task_bar_wnd_snap 储存配置。