### PR TITLE
修复了选项窗口调整窗口大小后滑动滚动条出现空白的bug

### DIFF
--- a/TrafficMonitor/TabDlg.cpp
+++ b/TrafficMonitor/TabDlg.cpp
@@ -82,6 +82,7 @@ void CTabDlg::ResetScroll()
 {
 	if (m_scroll_enable)
 	{
+		m_last_pos = 0;
 		SCROLLINFO scrollinfo;
 		GetScrollInfo(SB_VERT, &scrollinfo, SIF_ALL);
 		int step = scrollinfo.nPos - scrollinfo.nMin;


### PR DESCRIPTION
Bug复现步骤：
1、打开“选项设置”窗口并缩小窗口大小，确保滚动条能显示出来
2、滑动滚动条至最底部
3、调整窗口大小
4、滑动滚动条，此时界面顶部将出现空白区域