### PR TITLE
为任务栏窗口类添加了独立的DPI变量，用于修复任务栏窗口在不同DPI屏幕切换后显示不正常的bug

### DIFF
--- a/TrafficMonitor/TaskBarDlg.cpp
+++ b/TrafficMonitor/TaskBarDlg.cpp
@@ -579,6 +579,10 @@ void CTaskBarDlg::ApplyWindowTransparentColor()
 #endif // !COMPILE_FOR_WINXP
 }
 
+const RECT& CTaskBarDlg::GetSelfRect() const
+{
+    return m_rect;
+}
 
 void CTaskBarDlg::CheckTaskbarOnTopOrBottom()
 {
@@ -698,7 +702,7 @@ CString CTaskBarDlg::GetMouseTipsInfo()
     return tip_info;
 }
 
-void CTaskBarDlg::SetTextFont()
+void CTaskBarDlg::SetTextFontFromDPI(UINT dpi)
 {
     //如果m_font已经关联了一个字体资源对象，则释放它
     if (m_font.m_hObject)
@@ -706,7 +710,12 @@ void CTaskBarDlg::SetTextFont()
         m_font.DeleteObject();
     }
     //创建新的字体
-    theApp.m_taskbar_data.font.Create(m_font, theApp.GetDpi());
+    theApp.m_taskbar_data.font.Create(m_font, dpi);
+}
+
+void CTaskBarDlg::SetTextFont()
+{
+    SetTextFontFromDPI(theApp.GetDpi());
 }
 
 void CTaskBarDlg::ApplySettings()

--- a/TrafficMonitor/TaskBarDlg.cpp
+++ b/TrafficMonitor/TaskBarDlg.cpp
@@ -2,14 +2,14 @@
 //
 
 #include "stdafx.h"
-#include <shellscalingapi.h> //GetDpiForMonitor function
+#include <shellscalingapi.h> // 包含::GetDpiForMonitor
 #include "TrafficMonitor.h"
 #include "TaskBarDlg.h"
 #include "afxdialogex.h"
 #include "TrafficMonitorDlg.h"
 #include "WindowsSettingHelper.h"
 
-#pragma comment(lib, "Shcore.lib")
+#pragma comment(lib, "Shcore.lib") // 函数::GetDpiForMonitor依赖此lib
 
 // CTaskBarDlg 对话框
 

--- a/TrafficMonitor/TaskBarDlg.cpp
+++ b/TrafficMonitor/TaskBarDlg.cpp
@@ -2,12 +2,14 @@
 //
 
 #include "stdafx.h"
+#include <shellscalingapi.h> //GetDpiForMonitor function
 #include "TrafficMonitor.h"
 #include "TaskBarDlg.h"
 #include "afxdialogex.h"
 #include "TrafficMonitorDlg.h"
 #include "WindowsSettingHelper.h"
 
+#pragma comment(lib, "Shcore.lib")
 
 // CTaskBarDlg 对话框
 
@@ -79,7 +81,7 @@ void CTaskBarDlg::ShowInfo(CDC* pDC)
             if (theApp.m_taskbar_data.horizontal_arrange)   //水平排列
             {
                 if (index > 0)
-                    item_rect.MoveToX(item_rect.right + theApp.DPI(theApp.m_taskbar_data.item_space));
+                    item_rect.MoveToX(item_rect.right + DPI(theApp.m_taskbar_data.item_space));
                 item_rect.right = item_rect.left + iter->item_width.TotalWidth();
                 item_rect.bottom = item_rect.top + m_window_height;
                 if (iter->is_plugin)
@@ -94,7 +96,7 @@ void CTaskBarDlg::ShowInfo(CDC* pDC)
                 {
                     CRect item_rect_up;     //上面一个项目的矩形区域
                     if (index > 0)
-                        item_rect_up.MoveToXY(item_rect.right + theApp.DPI(theApp.m_taskbar_data.item_space), 0);
+                        item_rect_up.MoveToXY(item_rect.right + DPI(theApp.m_taskbar_data.item_space), 0);
                     item_rect.left = item_rect_up.left;
                     item_rect.top = (m_window_height - TASKBAR_WND_HEIGHT / 2);
                     //确定窗口大小
@@ -117,7 +119,7 @@ void CTaskBarDlg::ShowInfo(CDC* pDC)
                 //要绘制的项目为奇数时绘制最后一个
                 else if (item_count % 2 == 1 && index == item_count - 1)
                 {
-                    item_rect.MoveToXY(item_rect.right + theApp.DPI(theApp.m_taskbar_data.item_space), 0);
+                    item_rect.MoveToXY(item_rect.right + DPI(theApp.m_taskbar_data.item_space), 0);
                     item_rect.bottom = TASKBAR_WND_HEIGHT;
                     item_rect.right = item_rect.left + iter->item_width.MaxWidth();
                     if (iter->is_plugin)
@@ -131,9 +133,9 @@ void CTaskBarDlg::ShowInfo(CDC* pDC)
         else
         {
             if (index > 0)
-                item_rect.MoveToXY(0, item_rect.bottom + theApp.DPI(theApp.m_taskbar_data.item_space));
+                item_rect.MoveToXY(0, item_rect.bottom + DPI(theApp.m_taskbar_data.item_space));
             item_rect.bottom = item_rect.top + TASKBAR_WND_HEIGHT / 2;
-            item_rect.right = item_rect.left + min(m_window_width, m_rcMin.Width() - theApp.DPI(theApp.m_taskbar_data.item_space));
+            item_rect.right = item_rect.left + min(m_window_width, m_rcMin.Width() - DPI(theApp.m_taskbar_data.item_space));
             if (iter->is_plugin)
                 DrawPluginItem(draw, iter->plugin_item, item_rect, iter->item_width.label_width);
             else
@@ -489,12 +491,12 @@ bool CTaskBarDlg::AdjustWindowPos()
                             if (CWindowsSettingHelper::IsTaskbarChartBtnShown())
                                 taskbar_btn_num++;
 
-                            m_rect.MoveToX(m_rcMin.left - m_rect.Width() - 2 - theApp.DPI(44) * taskbar_btn_num);   //每个按钮44像素
+                            m_rect.MoveToX(m_rcMin.left - m_rect.Width() - 2 - DPI(44) * taskbar_btn_num);   //每个按钮44像素
                         }
                         else
                         {
                             if (CWindowsSettingHelper::IsTaskbarWidgetsBtnShown())
-                                m_rect.MoveToX(2 + theApp.DPI(theApp.m_cfg_data.taskbar_left_space_win11));
+                                m_rect.MoveToX(2 + DPI(theApp.m_cfg_data.taskbar_left_space_win11));
                             else
                                 m_rect.MoveToX(2);
                         }
@@ -512,7 +514,7 @@ bool CTaskBarDlg::AdjustWindowPos()
             }
             m_rect.MoveToY((m_rcBar.Height() - m_rect.Height()) / 2);
             if (theApp.m_taskbar_data.horizontal_arrange && theApp.m_win_version.IsWindows7())
-                m_rect.MoveToY(m_rect.top + theApp.DPI(1));
+                m_rect.MoveToY(m_rect.top + DPI(1));
             MoveWindow(m_rect);
         }
     }
@@ -535,8 +537,8 @@ bool CTaskBarDlg::AdjustWindowPos()
                 m_rect.MoveToY(m_top_space);
             }
             m_rect.MoveToX((m_rcMin.Width() - m_window_width) / 2);
-            if (m_rect.left < theApp.DPI(2))
-                m_rect.MoveToX(theApp.DPI(2));
+            if (m_rect.left < DPI(2))
+                m_rect.MoveToX(DPI(2));
             MoveWindow(m_rect);
         }
     }
@@ -583,6 +585,42 @@ const RECT& CTaskBarDlg::GetSelfRect() const
 {
     return m_rect;
 }
+
+UINT CTaskBarDlg::GetDPI() const
+{
+    return m_taskbar_dpi;
+}
+
+void CTaskBarDlg::SetDPI(UINT dpi)
+{
+    m_taskbar_dpi = dpi;
+}
+
+UINT CTaskBarDlg::DPI(UINT pixel) const
+{
+    return m_taskbar_dpi * pixel / 96;
+}
+
+void CTaskBarDlg::DPI(CRect& rect) const
+{
+    rect.left = DPI(rect.left);
+    rect.right = DPI(rect.right);
+    rect.top = DPI(rect.top);
+    rect.bottom = DPI(rect.bottom);
+}
+
+void CTaskBarDlg::DPIFromRect(const RECT& rect, UINT* out_dpi_x, UINT* out_dpi_y)
+{
+    HMONITOR h_current_monitor = ::MonitorFromRect(&rect, MONITOR_DEFAULTTONEAREST);
+    ::GetDpiForMonitor(h_current_monitor, MDT_EFFECTIVE_DPI, out_dpi_x, out_dpi_y);
+}
+
+CTaskBarDlg::ClassCheckWindowMonitorDPIAndHandle CTaskBarDlg::CheckWindowMonitorDPIAndHandle{};
+
+UINT CTaskBarDlg::ClassCheckWindowMonitorDPIAndHandle::buffered_dpi_x{0};
+UINT CTaskBarDlg::ClassCheckWindowMonitorDPIAndHandle::buffered_dpi_y{0};
+UINT CTaskBarDlg::ClassCheckWindowMonitorDPIAndHandle::dpi_x{0};
+UINT CTaskBarDlg::ClassCheckWindowMonitorDPIAndHandle::dpi_y{0};
 
 void CTaskBarDlg::CheckTaskbarOnTopOrBottom()
 {
@@ -702,7 +740,7 @@ CString CTaskBarDlg::GetMouseTipsInfo()
     return tip_info;
 }
 
-void CTaskBarDlg::SetTextFontFromDPI(UINT dpi)
+void CTaskBarDlg::SetTextFont()
 {
     //如果m_font已经关联了一个字体资源对象，则释放它
     if (m_font.m_hObject)
@@ -710,12 +748,7 @@ void CTaskBarDlg::SetTextFontFromDPI(UINT dpi)
         m_font.DeleteObject();
     }
     //创建新的字体
-    theApp.m_taskbar_data.font.Create(m_font, dpi);
-}
-
-void CTaskBarDlg::SetTextFont()
-{
-    SetTextFontFromDPI(theApp.GetDpi());
+    theApp.m_taskbar_data.font.Create(m_font, GetDPI());
 }
 
 void CTaskBarDlg::ApplySettings()
@@ -832,7 +865,7 @@ void CTaskBarDlg::CalculateWindowSize()
     else
         str = _T("99°C");
     value_width = m_pDC->GetTextExtent(str).cx;
-    value_width += theApp.DPI(2);
+    value_width += DPI(2);
     item_widths[TDI_CPU_TEMP].value_width = value_width;
     item_widths[TDI_GPU_TEMP].value_width = value_width;
     item_widths[TDI_HDD_TEMP].value_width = value_width;
@@ -878,7 +911,7 @@ void CTaskBarDlg::CalculateWindowSize()
             {
                 m_window_width += iter->item_width.TotalWidth();
             }
-            m_window_width += theApp.DPI(theApp.m_taskbar_data.item_space) * item_count;   //加上每个标签间的空隙
+            m_window_width += DPI(theApp.m_taskbar_data.item_space) * item_count;   //加上每个标签间的空隙
         }
         else        //非水平排列时，每两个一组排列
         {
@@ -902,7 +935,7 @@ void CTaskBarDlg::CalculateWindowSize()
                 index++;
             }
 
-            m_window_width += theApp.DPI(theApp.m_taskbar_data.item_space) * ((item_count + 1) / 2 + 1);   //加上每个标签间的空隙
+            m_window_width += DPI(theApp.m_taskbar_data.item_space) * ((item_count + 1) / 2 + 1);   //加上每个标签间的空隙
         }
     }
     else        //任务栏在桌面两侧时
@@ -927,7 +960,7 @@ void CTaskBarDlg::CalculateWindowSize()
     else
     {
         m_window_height = TASKBAR_WND_HEIGHT / 2 * item_count;
-        m_window_height += (theApp.DPI(theApp.m_taskbar_data.item_space) * item_count);   //加上每个标签间的空隙
+        m_window_height += (DPI(theApp.m_taskbar_data.item_space) * item_count);   //加上每个标签间的空隙
     }
     m_rect.right = m_rect.left + m_window_width;
     m_rect.bottom = m_rect.top + m_window_height;
@@ -976,9 +1009,6 @@ BOOL CTaskBarDlg::OnInitDialog()
     m_pDC = GetDC();
 
 
-    //设置字体
-    SetTextFont();
-    m_pDC->SelectObject(&m_font);
 
 
     m_hTaskbar = ::FindWindow(L"Shell_TrayWnd", NULL);      //寻找类名是Shell_TrayWnd的窗口句柄
@@ -997,6 +1027,22 @@ BOOL CTaskBarDlg::OnInitDialog()
     ::GetWindowRect(m_hBar, m_rcBar);   //获得二级容器的区域
     m_left_space = m_rcMin.left - m_rcBar.left;
     m_top_space = m_rcMin.top - m_rcBar.top;
+
+    //根据已经确定的任务栏最小化窗口区域得到屏幕并获得所在屏幕的DPI（Windows 8.1及其以上）
+    if (theApp.m_win_version.IsWindows8Point1OrLater())
+    {
+        UINT dpi_x, dpi_y;
+        DPIFromRect(m_rcMin, &dpi_x, &dpi_y);
+        SetDPI(dpi_x);
+    }
+    else
+    {
+        SetDPI(theApp.GetDpi());
+    }
+
+    //设置字体
+    SetTextFont();
+    m_pDC->SelectObject(&m_font);
 
     CheckTaskbarOnTopOrBottom();
     CalculateWindowSize();

--- a/TrafficMonitor/TaskBarDlg.h
+++ b/TrafficMonitor/TaskBarDlg.h
@@ -31,6 +31,8 @@ public:
     bool AdjustWindowPos();	//设置窗口在任务栏中的位置
     void ApplyWindowTransparentColor();
 
+    const RECT& GetSelfRect() const;
+
     // 对话框数据
 #ifdef AFX_DESIGN_TIME
     enum { IDD = IDD_TASK_BAR_DIALOG };
@@ -129,6 +131,7 @@ protected:
     void MoveWindow(CRect rect);
 
 public:
+    void SetTextFontFromDPI(UINT dpi);
     void SetTextFont();
     void ApplySettings();
     void CalculateWindowSize();		//计算窗口每部分的大小，及各个部分的宽度。窗口大小保存到m_window_width和m_window_height中，各部分宽度保存到m_item_widths中

--- a/TrafficMonitor/TaskBarDlg.h
+++ b/TrafficMonitor/TaskBarDlg.h
@@ -8,7 +8,7 @@
 #include <list>
 
 // CTaskBarDlg 对话框
-#define TASKBAR_WND_HEIGHT theApp.DPI(32)				//任务栏窗口的高度
+#define TASKBAR_WND_HEIGHT DPI(32)				//任务栏窗口的高度
 #define WM_TASKBAR_MENU_POPED_UP (WM_USER + 1004)		//定义任务栏窗口右键菜单弹出时发出的消息
 //#define TASKBAR_GRAPH_MAX_LEN 600						//历史数据存储最大长度
 #define TASKBAR_GRAPH_STEP 5							//几秒钟画一条线
@@ -32,6 +32,39 @@ public:
     void ApplyWindowTransparentColor();
 
     const RECT& GetSelfRect() const;
+
+    UINT GetDPI() const;
+    void SetDPI(UINT dpi);
+    UINT DPI(UINT pixel) const;
+    void DPI(CRect& rect) const;
+
+    static void DPIFromRect(const RECT& rect, UINT* out_dpi_x, UINT* out_dpi_y);
+    //下面的类定义可以看做函数定义，避免模板函数不同实例化导致静态变量不同。
+    // 近似函数声明
+    // template <class HanlderFunc>
+    // CheckWindowMonitorDPIAndHandle(CTaskBarDlg& ref_taskbar_window, HanlderFunc handler)
+    static class ClassCheckWindowMonitorDPIAndHandle
+    {
+    public:
+        template <class HandlerFunc>
+        void operator()(CTaskBarDlg& ref_taskbar_window, HandlerFunc handler)
+        {
+            DPIFromRect(ref_taskbar_window.GetSelfRect(), &dpi_x, &dpi_y);
+            //只取dpi_x作为程序dpi
+            if (dpi_x != buffered_dpi_x || dpi_y != buffered_dpi_y)
+            {
+                //更新缓存的数据
+                buffered_dpi_x = dpi_x;
+                buffered_dpi_y = dpi_y;
+                //调用用户自定义处理方法
+                handler(dpi_x, dpi_y);
+            }
+        }
+
+    private:
+        static UINT buffered_dpi_x, buffered_dpi_y;
+        static UINT dpi_x, dpi_y;
+    } CheckWindowMonitorDPIAndHandle;
 
     // 对话框数据
 #ifdef AFX_DESIGN_TIME
@@ -98,6 +131,8 @@ protected:
     int m_error_code{};
     bool m_menu_popuped{ false };               //指示当前是否有菜单处于弹出状态
 
+    UINT m_taskbar_dpi{};//TaskBarDlg自身专用dpi
+
     CFont m_font;			//字体
 
     CDC* m_pDC{};		//窗口的DC，用来计算窗口的宽度
@@ -131,7 +166,6 @@ protected:
     void MoveWindow(CRect rect);
 
 public:
-    void SetTextFontFromDPI(UINT dpi);
     void SetTextFont();
     void ApplySettings();
     void CalculateWindowSize();		//计算窗口每部分的大小，及各个部分的宽度。窗口大小保存到m_window_width和m_window_height中，各部分宽度保存到m_item_widths中

--- a/TrafficMonitor/TrafficMonitorDlg.h
+++ b/TrafficMonitor/TrafficMonitorDlg.h
@@ -93,6 +93,7 @@ protected:
 
     int m_restart_cnt{ -1 };    //重新初始化次数
     unsigned int m_timer_cnt{};     //定时器触发次数（自程序启动以来的秒数）
+    unsigned int m_taskbar_timer_cnt{0}; //适用于TaskBarDlg的定时器触发次数（自程序启动以来的秒数）
     unsigned int m_monitor_time_cnt{};
     int m_zero_speed_cnt{}; //如果检测不到网速，该变量就会自加
     int m_insert_to_taskbar_cnt{};  //用来统计尝试嵌入任务栏的次数

--- a/TrafficMonitor/WinVersionHelper.cpp
+++ b/TrafficMonitor/WinVersionHelper.cpp
@@ -64,6 +64,19 @@ bool CWinVersionHelper::IsWindows8Or8point1() const
 	return (m_major_version == 6 && m_minor_version > 1);
 }
 
+bool CWinVersionHelper::IsWindows8Point1OrLater() const
+{
+	if (m_major_version > 6)
+    {
+        return true;
+    }
+    else if (m_major_version == 6 && m_minor_version >= 3)
+    {
+        return true;
+    }
+    return false;
+}
+
 bool CWinVersionHelper::IsWindows8OrLater() const
 {
     if (m_major_version > 6)

--- a/TrafficMonitor/WinVersionHelper.h
+++ b/TrafficMonitor/WinVersionHelper.h
@@ -9,6 +9,7 @@ public:
 	bool IsWindows10FallCreatorOrLater() const;		//判断当前Windows版本是否为Win10秋季创意者更新或更新的版本
 	bool IsWindows7() const;					//判断Windows版本是否为Windows7
 	bool IsWindows8Or8point1() const;			//判断Windows版本是否为Windows8或Windows8.1
+    bool IsWindows8Point1OrLater() const;       //判断Windows版本是否大于等于Windows8.1
     bool IsWindows8OrLater() const;
     bool IsWindows10OrLater() const;
 


### PR DESCRIPTION
新增的Windows 8.1版本检测在虚拟机上测试通过。修复bug后的程序在win 11上加载了天气插件和电池功耗插件后，在不同DPI屏幕之间切换后运行正常。 

fix #1089