### PR TITLE
监控间隔最大值调整为30s

### DIFF
--- a/TrafficMonitor/CommonData.h
+++ b/TrafficMonitor/CommonData.h
@@ -355,7 +355,7 @@ struct GeneralSettingData
 
 //定义监控时间间隔有效的最大值和最小值
 #define MONITOR_TIME_SPAN_MIN 200
-#define MONITOR_TIME_SPAN_MAX 2000
+#define MONITOR_TIME_SPAN_MAX 30000
 
 enum class Alignment
 {

--- a/TrafficMonitor/TrafficMonitorDlg.cpp
+++ b/TrafficMonitor/TrafficMonitorDlg.cpp
@@ -1031,7 +1031,9 @@ HCURSOR CTrafficMonitorDlg::OnQueryDragIcon()
 //计算指定秒数的时间内Monitor定时器会触发的次数
 static int GetMonitorTimerCount(int second)
 {
-    return second * 1000 / theApp.m_general_data.monitor_time_span;
+    int count = second * 1000 / theApp.m_general_data.monitor_time_span;
+    if (count <= 0) count = 1;
+    return count;
 }
 
 
@@ -1168,7 +1170,6 @@ UINT CTrafficMonitorDlg::MonitorThreadCallback(LPVOID dwUser)
         info.Replace(_T("<%cnt%>"), CCommon::IntToString(pThis->m_restart_cnt));
         CCommon::WriteLog(info, theApp.m_log_path.c_str());
     }
-
 
     if (pThis->m_monitor_time_cnt % GetMonitorTimerCount(3) == GetMonitorTimerCount(3) - 1)
     {


### PR DESCRIPTION
有的场景只需要看个基本的监控数值，不要求多实时。
这里把监控间隔时间改到受 short 类型限制的最大值（30000ms）（原本想改到1分钟级别，但是还要适配其他地方就先算了吧）。
为保证监控线程回调逻辑正常运行，修改 GetMonitorTimerCount ，当在指定秒数内 定时器触发不足一次时，默认为1次。