### PR TITLE
更新workflow actions版本, github将弃用旧版输出

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,23 +5,23 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v1.1.3
       
     - name: Run msbuild
       run: msbuild -p:configuration=release -p:platform=x64 -p:platformToolset=v142
       
     - name: Get current time
-      uses: 1466587594/current-time@v1
+      uses: josStorer/get-current-time@v2.0.2
       id: current-time
       with:
         format: YYYYMMDD_HHmmss
         utcOffset: "+08:00"
       
     - name : Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: x64_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
         path: |
@@ -29,7 +29,7 @@ jobs:
           Bin/x64/Release/*.dll
 
     - name : Upload pdb files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: x64_${{ steps.current-time.outputs.formattedTime }}_pdb
         path: Bin/x64/Release/*.pdb
@@ -38,23 +38,23 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v1.1.3
       
     - name: Run msbuild
       run: msbuild -p:configuration=release -p:platform=x86 -p:platformToolset=v142
       
     - name: Get current time
-      uses: 1466587594/current-time@v1
+      uses: josStorer/get-current-time@v2.0.2
       id: current-time
       with:
         format: YYYYMMDD_HHmmss
         utcOffset: "+08:00"
       
     - name : Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: x86_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
         path: |
@@ -62,7 +62,7 @@ jobs:
           Bin/Release/*.dll
       
     - name : Upload pdb files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: x86_${{ steps.current-time.outputs.formattedTime }}_pdb
         path: Bin/Release/*.pdb
@@ -71,10 +71,10 @@ jobs:
     # runs-on: windows-latest
 
     # steps:
-    # - uses: actions/checkout@v2
+    # - uses: actions/checkout@v3
       
     # - name: Add msbuild to PATH
-      # uses: microsoft/setup-msbuild@v1
+      # uses: microsoft/setup-msbuild@v1.1.3
       
     # - name: Run msbuild
       # run: |
@@ -83,14 +83,14 @@ jobs:
       # shell: cmd
       
     # - name: Get current time
-      # uses: 1466587594/current-time@v1
+      # uses: josStorer/get-current-time@v2.0.2
       # id: current-time
       # with:
         # format: YYYYMMDD_HHmmss
         # utcOffset: "+08:00"
       
     # - name : Upload artifact
-      # uses: actions/upload-artifact@v1
+      # uses: actions/upload-artifact@v3
       # with:
         # name: winXP_${{ steps.current-time.outputs.formattedTime }}_TrafficMonitor
         # path: Bin/Release/TrafficMonitor.exe


### PR DESCRIPTION
Github说明: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

相关actions更新:
https://github.com/microsoft/setup-msbuild/releases/tag/v1.1.3
https://github.com/josStorer/get-current-time/releases/tag/v2.0.2

使用旧版的警告: josStorer/get-current-time#6

本PR的构建测试结果: https://github.com/josStorer/TrafficMonitor/actions/runs/3246841116
