### PR TITLE
Increase top offset range from 5 to 20

### DIFF
--- a/TrafficMonitor/CommonData.cpp
+++ b/TrafficMonitor/CommonData.cpp
@@ -165,8 +165,8 @@ void TaskBarSettingData::ValidWindowOffsetTop()
 {
     if (window_offset_top < -5)
         window_offset_top = -5;
-    if (window_offset_top > 5)
-        window_offset_top = 5;
+    if (window_offset_top > 20)
+        window_offset_top = 20;
 }
 
 void TaskBarSettingData::ValidVerticalMargin()

--- a/TrafficMonitor/TaskBarSettingsDlg.cpp
+++ b/TrafficMonitor/TaskBarSettingsDlg.cpp
@@ -317,7 +317,7 @@ BOOL CTaskBarSettingsDlg::OnInitDialog()
     m_item_space_edit.SetRange(0, 32);
     m_item_space_edit.SetValue(m_data.item_space);
     CTaskBarDlg* taskbar_dlg{ CTrafficMonitorDlg::Instance()->GetTaskbarWindow() };
-    m_window_offset_top_edit.SetRange(-5, 5);
+    m_window_offset_top_edit.SetRange(-5, 20);
     m_window_offset_top_edit.SetValue(m_data.window_offset_top);
     if (taskbar_dlg != nullptr)
         m_window_offset_top_edit.EnableWindow(taskbar_dlg->IsTasksbarOnTopOrBottom());


### PR DESCRIPTION
5 points is too less and does not fix the position of the taskbar on high dpi tablet taskbars. 20 should be sufficient. More negative is not required as the issue such as #1554 only requires more offset and not negative.