### PR TITLE
fix: 修复D3D设备丢失时重新创建的设备不齐全的问题

### DIFF
--- a/TrafficMonitor/TaskBarDlgDrawCommon.cpp
+++ b/TrafficMonitor/TaskBarDlgDrawCommon.cpp
@@ -198,13 +198,20 @@ bool CTaskBarDlgDrawCommonSupport::IsAllDevicesRecreatedByThisFunction()
     auto hr = p_d3d10_device1->GetDeviceRemovedReason();
     if (hr != S_OK)
     {
-        CCommon::WriteLog(
-            "D3D10.1 device is invalid. All devices will be recreated.",
-            theApp.m_log_path.c_str());
+        CCommon::WriteLog("Notice: D3D10.1 device is invalid. All devices will be recreated. This message is sent by "
+                          "the function on the next line:",
+                          theApp.m_log_path.c_str());
+        CCommon::WriteLog(__FUNCSIG__, theApp.m_log_path.c_str());
         RecreateAll();
         return true;
     }
     return false;
+}
+
+void CTaskBarDlgDrawCommonSupport::InternalRecreateD3D10Device1()
+{
+    auto &&default_adapter1 = CD3D10Support1::GetDeviceList(true).front();
+    m_d3d10_device1.Recreate(default_adapter1);
 }
 
 CTaskBarDlgDrawCommonSupport::CTaskBarDlgDrawCommonSupport()
@@ -259,7 +266,10 @@ auto CTaskBarDlgDrawCommonSupport::GetPsDotLikeStyle() noexcept
 
 void CTaskBarDlgDrawCommonSupport::RecreateAll()
 {
-    RecreateD3D10Device1();
+    CCommon::WriteLog("Notice: All devices will be recreated. This message is sent by the function on the next line:",
+                      theApp.m_log_path.c_str());
+    CCommon::WriteLog(__FUNCSIG__, theApp.m_log_path.c_str());
+    InternalRecreateD3D10Device1();
     RecreateD2D1Device();
     RecreateDCompositionDevice();
 }
@@ -269,11 +279,12 @@ void CTaskBarDlgDrawCommonSupport::RecreateD3D10Device1(const HRESULT recreate_r
     if (recreate_reason != S_OK)
     {
         DrawCommonHelper::LogDeviceRecreateReason(recreate_reason);
-        CCommon::WriteLog("Notice: The D3D10.1 device will be recreated.", theApp.m_log_path.c_str());
+        CCommon::WriteLog("Notice: D3D10.1 device is invalid. All devices will be recreated. This message is sent by "
+                          "the function on the next line:",
+                          theApp.m_log_path.c_str());
+        CCommon::WriteLog(__FUNCSIG__, theApp.m_log_path.c_str());
     }
-    auto&& default_adapter1 =
-        CD3D10Support1::GetDeviceList(true).front();
-    m_d3d10_device1.Recreate(default_adapter1);
+    RecreateAll();
 }
 
 void CTaskBarDlgDrawCommonSupport::RecreateD2D1Device(const HRESULT recreate_reason)
@@ -281,7 +292,10 @@ void CTaskBarDlgDrawCommonSupport::RecreateD2D1Device(const HRESULT recreate_rea
     if (recreate_reason != S_OK)
     {
         DrawCommonHelper::LogDeviceRecreateReason(recreate_reason);
-        CCommon::WriteLog("Notice: The D2D1 device will be recreated.", theApp.m_log_path.c_str());
+        CCommon::WriteLog(
+            "Notice: The D2D1 device will be recreated. This message is sent by the function on the next line:",
+            theApp.m_log_path.c_str());
+        CCommon::WriteLog(__FUNCSIG__, theApp.m_log_path.c_str());
     }
     if (IsAllDevicesRecreatedByThisFunction())
     {
@@ -299,7 +313,9 @@ void CTaskBarDlgDrawCommonSupport::RecreateDCompositionDevice(const HRESULT recr
     if (recreate_reason != S_OK)
     {
         DrawCommonHelper::LogDeviceRecreateReason(recreate_reason);
-        CCommon::WriteLog("Notice: The DirectComposition device will be recreated.", theApp.m_log_path.c_str());
+        CCommon::WriteLog("Notice: The DirectComposition device will be recreated. This message is sent by the function on the next line:",
+            theApp.m_log_path.c_str());
+        CCommon::WriteLog(__FUNCSIG__, theApp.m_log_path.c_str());
     }
     if (IsAllDevicesRecreatedByThisFunction())
     {

--- a/TrafficMonitor/TaskBarDlgDrawCommon.h
+++ b/TrafficMonitor/TaskBarDlgDrawCommon.h
@@ -132,6 +132,7 @@ private:
     Microsoft::WRL::ComPtr<ID2D1StrokeStyle> m_p_ps_dot_like_style{};
 
     bool IsAllDevicesRecreatedByThisFunction();
+    void InternalRecreateD3D10Device1();
 
 public:
     CTaskBarDlgDrawCommonSupport();


### PR DESCRIPTION
之前在重新创建D3D设备时，不会一并创建D2D和DComposition设备，导致后续绘图时不断出现异常。

添加了更多日志信息：在重新创建图形设备时的日志会记录当前方法名。

CI地址：https://github.com/BombaxCeiba/TrafficMonitor/actions/runs/5582184387