### PR TITLE
修复在运行时调整屏幕分辨率导致整个任务栏消失的问题

### DIFF
--- a/TrafficMonitor/TrafficMonitorDlg.cpp
+++ b/TrafficMonitor/TrafficMonitorDlg.cpp
@@ -551,6 +551,7 @@ void CTrafficMonitorDlg::CloseTaskBarWnd()
 
 void CTrafficMonitorDlg::OpenTaskBarWnd()
 {
+    CloseTaskBarWnd(); // 防止创建多个实例，内存泄露
     m_tBarDlg = new CTaskBarDlg;
 
     CSupportedRenderEnums supported_render_enums{};
@@ -2771,6 +2772,7 @@ LRESULT CTrafficMonitorDlg::OnDisplaychange(WPARAM wParam, LPARAM lParam)
 {
     GetScreenSize();
     CheckWindowPos(true);
+    OpenTaskBarWnd(); // 重新创建任务栏窗口
     return 0;
 }
 


### PR DESCRIPTION
I have only ran it on win11. 
I use a 4K monitor. This problem is likely to occur when I adjust the resolution to 2K or 1K.
Especially when playing full-screen games. If the resolution of your game settings is inconsistent with the actual resolution of the screen. At this time, you return to the desktop from the game screen. The problem is likely to recur.
My initial guess is that the taskbar will be temporarily invalid when adjusting the screen resolution. This may cause this problem to occur.

**My solution is to recreate the taskbar window when receiving the WM_DISPLAYCHANGE message**