### PR TITLE
修复悬浮提示某些情况下会丢失置顶

### DIFF
--- a/TrafficMonitor/TaskBarDlg.cpp
+++ b/TrafficMonitor/TaskBarDlg.cpp
@@ -936,7 +936,7 @@ void CTaskBarDlg::CalculateWindowSize()
 
 void CTaskBarDlg::SetToolTipsTopMost()
 {
-    m_tool_tips.SetWindowPos(&wndTopMost, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+    m_tool_tips.SetWindowPos(&wndTopMost, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_SHOWWINDOW);
 }
 
 void CTaskBarDlg::UpdateToolTips()


### PR DESCRIPTION
SWP_SHOWWINDOW作用：确保窗口“可见 + 重新刷一遍 Z 序”