### PR TITLE
修复选项设置中子页面DPI不一致的问题

### DIFF
--- a/TrafficMonitor/BaseDialog.cpp
+++ b/TrafficMonitor/BaseDialog.cpp
@@ -315,9 +315,14 @@ BOOL CBaseDialog::OnInitDialog()
     FontInfo font_info;
     font_info.name = theApp.m_str_table.GetLanguageInfo().default_font_name.c_str();
     font_info.size = 9;
-    UINT dpi_x{}, dpi_y{};
-    if (theApp.DPIFromRect(rect, &dpi_x, &dpi_y))
-        m_dpi = dpi_x;
+    // 对于子窗口（如TabDlg），不根据窗口位置重新检测DPI，因为创建时位置还未确定
+    // 保持构造函数中设置的 theApp.GetDpi() 值
+    if ((GetStyle() & WS_CHILD) == 0)
+    {
+        UINT dpi_x{}, dpi_y{};
+        if (theApp.DPIFromRect(rect, &dpi_x, &dpi_y))
+            m_dpi = dpi_x;
+    }
 
     font_info.Create(m_dlg_font, m_dpi);
 


### PR DESCRIPTION
## 问题描述

在选项设置中，子页面存在 DPI 不一致的情况，导致控件尺寸显示不同。

## 修复内容

- 修复选项设置中子页面DPI不一致导致控件尺寸不同的问题

## 测试

已在同时连接两种不同分辨率的显示器屏幕上测试
1920 x 1080
2560 x 1440
