### PR TITLE
feat: 硬件监控数据获取失败时采用指数退避策略

### DIFF
--- a/TrafficMonitor/TrafficMonitorDlg.cpp
+++ b/TrafficMonitor/TrafficMonitorDlg.cpp
@@ -805,6 +805,11 @@ void CTrafficMonitorDlg::ApplySettings(COptionsDlg& optionsDlg)
 #ifndef WITHOUT_TEMPERATURE
     if (is_hardware_monitor_item_changed)
     {
+        // 重置硬件监控错误状态，允许用户在解决问题后重新启用
+        m_hardware_monitor_error_cnt = 0;
+        m_hardware_monitor_error_shown = false;
+        m_hardware_monitor_disabled_by_error = false;
+
         //如果关闭了硬件监控，则析构硬件监控类
         if (theApp.m_general_data.hardware_monitor_item == 0)
         {
@@ -1357,12 +1362,7 @@ void CTrafficMonitorDlg::DoMonitorAcquisition()
     bool gpu_usage_acquired = false;
     m_get_disk_usage_by_pdh = false;
 
-    theApp.m_cpu_temperature = -1;
-    theApp.m_gpu_temperature = -1;
-    theApp.m_hdd_temperature = -1;
-    theApp.m_main_board_temperature = -1;
-    theApp.m_gpu_usage = -1;
-    theApp.m_hdd_usage = -1;
+    // 不再每次都重置为-1，而是通过失败计数器来决定是否显示"--"
 
     //获取CPU使用率
     if (lite_version || theApp.m_general_data.cpu_usage_acquire_method != GeneralSettingData::CA_HARDWARE_MONITOR || !theApp.m_general_data.IsHardwareEnable(HI_CPU))
@@ -1422,10 +1422,11 @@ void CTrafficMonitorDlg::DoMonitorAcquisition()
 
 #ifndef WITHOUT_TEMPERATURE
     //获取温度
-    if (IsTemperatureNeeded() && theApp.m_pMonitor != nullptr)
+    if (IsTemperatureNeeded() && theApp.m_pMonitor != nullptr && !m_hardware_monitor_disabled_by_error)
     {
         CSingleLock sync(&theApp.m_minitor_lib_critical, TRUE);
         CString error_info = CCommon::LoadText(IDS_HARDWARE_INFO_ACQUIRE_FAILED_ERROR);
+        bool hardware_info_error = false;
 
         auto getHardwareInfo = [&]() {
             __try
@@ -1434,7 +1435,7 @@ void CTrafficMonitorDlg::DoMonitorAcquisition()
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
             {
-                AfxMessageBox(error_info, MB_ICONERROR | MB_OK);
+                hardware_info_error = true;
             }
         };
 
@@ -1442,58 +1443,200 @@ void CTrafficMonitorDlg::DoMonitorAcquisition()
         auto monitor_error_message{ OpenHardwareMonitorApi::GetErrorMessage() };
         if (!monitor_error_message.empty())
         {
-            AfxMessageBox(monitor_error_message.c_str(), MB_ICONERROR | MB_OK);
+            hardware_info_error = true;
         }
-        //theApp.m_cpu_temperature = theApp.m_pMonitor->CpuTemperature();
-        theApp.m_gpu_temperature = theApp.m_pMonitor->GpuTemperature();
-        //theApp.m_hdd_temperature = theApp.m_pMonitor->HDDTemperature();
-        theApp.m_main_board_temperature = theApp.m_pMonitor->MainboardTemperature();
-        if (!gpu_usage_acquired)
-            theApp.m_gpu_usage = theApp.m_pMonitor->GpuUsage();
-        if (!cpu_freq_acquired)
-            theApp.m_cpu_freq = theApp.m_pMonitor->CpuFreq();
-        if (!cpu_usage_acquired)
-            theApp.m_cpu_usage = theApp.m_pMonitor->CpuUsage();
-        //获取CPU温度
-        if (!theApp.m_pMonitor->AllCpuTemperature().empty())
+
+        if (hardware_info_error)
         {
-            if (theApp.m_general_data.cpu_core_name == CCommon::LoadText(IDS_AVREAGE_TEMPERATURE).GetString())  //如果选择了平均温度
+            m_hardware_monitor_error_cnt++;
+            // 写入日志
+            CString log_info;
+            log_info.Format(_T("Hardware monitor error count: %d/%d"), m_hardware_monitor_error_cnt, MAX_HARDWARE_MONITOR_ERRORS);
+            CCommon::WriteLog(log_info, theApp.m_log_path.c_str());
+
+            if (!monitor_error_message.empty())
             {
-                theApp.m_cpu_temperature = theApp.m_pMonitor->CpuTemperature();
+                CCommon::WriteLog(CString(monitor_error_message.c_str()), theApp.m_log_path.c_str());
+            }
+
+            // 只在第一次错误时弹出提示
+            if (!m_hardware_monitor_error_shown)
+            {
+                CString msg;
+                if (!monitor_error_message.empty())
+                {
+                    msg = monitor_error_message.c_str();
+                }
+                else
+                {
+                    msg = error_info;
+                }
+                AfxMessageBox(msg, MB_ICONERROR | MB_OK);
+                m_hardware_monitor_error_shown = true;
+            }
+
+            // 连续错误达到阈值后自动禁用硬件监控
+            if (m_hardware_monitor_error_cnt >= MAX_HARDWARE_MONITOR_ERRORS)
+            {
+                m_hardware_monitor_disabled_by_error = true;
+                CString disable_msg = CCommon::LoadText(_T("Hardware monitoring has been automatically disabled due to persistent errors.\n")
+                    _T("You can re-enable it in Options after resolving the issue (e.g., updating GPU driver)."));
+                CCommon::WriteLog(disable_msg, theApp.m_log_path.c_str());
+                AfxMessageBox(disable_msg, MB_ICONWARNING | MB_OK);
+            }
+        }
+        else
+        {
+            // 成功时重置错误计数器
+            if (m_hardware_monitor_error_cnt > 0)
+            {
+                m_hardware_monitor_error_cnt = 0;
+                m_hardware_monitor_error_shown = false;
+            }
+        }
+
+        // 即使有错误也继续获取数据（可能是部分硬件有问题）
+        // 使用失败计数器：只有连续失败达到阈值才显示"--"
+
+        // 获取显卡温度
+        {
+            float gpu_temp = theApp.m_pMonitor->GpuTemperature();
+            if (gpu_temp > 0)
+            {
+                theApp.m_gpu_temperature = gpu_temp;
+                m_gpu_temp_fail_cnt = 0;
             }
             else
             {
-                auto iter = theApp.m_pMonitor->AllCpuTemperature().find(theApp.m_general_data.cpu_core_name);
-                if (iter == theApp.m_pMonitor->AllCpuTemperature().end())
-                {
-                    iter = theApp.m_pMonitor->AllCpuTemperature().begin();
-                    theApp.m_general_data.cpu_core_name = iter->first;
-                }
-                theApp.m_cpu_temperature = iter->second;
+                m_gpu_temp_fail_cnt++;
+                if (m_gpu_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_gpu_temperature = -1;
             }
         }
-        else
+
+        // 获取主板温度
         {
-            theApp.m_cpu_temperature = -1;
-        }
-        //获取硬盘温度
-        if (!theApp.m_pMonitor->AllHDDTemperature().empty())
-        {
-            auto iter = theApp.m_pMonitor->AllHDDTemperature().find(theApp.m_general_data.hard_disk_name);
-            if (iter == theApp.m_pMonitor->AllHDDTemperature().end())
+            float mainboard_temp = theApp.m_pMonitor->MainboardTemperature();
+            if (mainboard_temp > 0)
             {
-                iter = theApp.m_pMonitor->AllHDDTemperature().begin();
-                theApp.m_general_data.hard_disk_name = iter->first;
+                theApp.m_main_board_temperature = mainboard_temp;
+                m_mainboard_temp_fail_cnt = 0;
             }
-            theApp.m_hdd_temperature = iter->second;
+            else
+            {
+                m_mainboard_temp_fail_cnt++;
+                if (m_mainboard_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_main_board_temperature = -1;
+            }
         }
-        else
+
+        // 获取显卡利用率
+        if (!gpu_usage_acquired)
         {
-            theApp.m_hdd_temperature = -1;
+            int gpu_usage = theApp.m_pMonitor->GpuUsage();
+            if (gpu_usage >= 0)
+            {
+                theApp.m_gpu_usage = gpu_usage;
+                m_gpu_usage_fail_cnt = 0;
+            }
+            else
+            {
+                m_gpu_usage_fail_cnt++;
+                if (m_gpu_usage_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_gpu_usage = -1;
+            }
         }
-        //获取硬盘利用率
+
+        // 获取CPU频率
+        if (!cpu_freq_acquired)
+        {
+            float cpu_freq = theApp.m_pMonitor->CpuFreq();
+            if (cpu_freq > 0)
+            {
+                theApp.m_cpu_freq = cpu_freq;
+                m_cpu_freq_fail_cnt = 0;
+            }
+            else
+            {
+                m_cpu_freq_fail_cnt++;
+                if (m_cpu_freq_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_cpu_freq = -1;
+            }
+        }
+
+        // 获取CPU利用率
+        if (!cpu_usage_acquired)
+        {
+            int cpu_usage = theApp.m_pMonitor->CpuUsage();
+            if (cpu_usage >= 0)
+            {
+                theApp.m_cpu_usage = cpu_usage;
+            }
+        }
+
+        // 获取CPU温度
+        {
+            float cpu_temp = -1;
+            if (!theApp.m_pMonitor->AllCpuTemperature().empty())
+            {
+                if (theApp.m_general_data.cpu_core_name == CCommon::LoadText(IDS_AVREAGE_TEMPERATURE).GetString())  //如果选择了平均温度
+                {
+                    cpu_temp = theApp.m_pMonitor->CpuTemperature();
+                }
+                else
+                {
+                    auto iter = theApp.m_pMonitor->AllCpuTemperature().find(theApp.m_general_data.cpu_core_name);
+                    if (iter == theApp.m_pMonitor->AllCpuTemperature().end())
+                    {
+                        iter = theApp.m_pMonitor->AllCpuTemperature().begin();
+                        theApp.m_general_data.cpu_core_name = iter->first;
+                    }
+                    cpu_temp = iter->second;
+                }
+            }
+            if (cpu_temp > 0)
+            {
+                theApp.m_cpu_temperature = cpu_temp;
+                m_cpu_temp_fail_cnt = 0;
+            }
+            else
+            {
+                m_cpu_temp_fail_cnt++;
+                if (m_cpu_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_cpu_temperature = -1;
+            }
+        }
+
+        // 获取硬盘温度
+        {
+            float hdd_temp = -1;
+            if (!theApp.m_pMonitor->AllHDDTemperature().empty())
+            {
+                auto iter = theApp.m_pMonitor->AllHDDTemperature().find(theApp.m_general_data.hard_disk_name);
+                if (iter == theApp.m_pMonitor->AllHDDTemperature().end())
+                {
+                    iter = theApp.m_pMonitor->AllHDDTemperature().begin();
+                    theApp.m_general_data.hard_disk_name = iter->first;
+                }
+                hdd_temp = iter->second;
+            }
+            if (hdd_temp > 0)
+            {
+                theApp.m_hdd_temperature = hdd_temp;
+                m_hdd_temp_fail_cnt = 0;
+            }
+            else
+            {
+                m_hdd_temp_fail_cnt++;
+                if (m_hdd_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_hdd_temperature = -1;
+            }
+        }
+
+        // 获取硬盘利用率
         if (!m_get_disk_usage_by_pdh)
         {
+            int hdd_usage = -1;
             if (!theApp.m_pMonitor->AllHDDUsage().empty())
             {
                 auto iter = theApp.m_pMonitor->AllHDDUsage().find(theApp.m_general_data.hard_disk_name);
@@ -1502,13 +1645,47 @@ void CTrafficMonitorDlg::DoMonitorAcquisition()
                     iter = theApp.m_pMonitor->AllHDDUsage().begin();
                     theApp.m_general_data.hard_disk_name = iter->first;
                 }
-                theApp.m_hdd_usage = iter->second;
+                hdd_usage = iter->second;
+            }
+            if (hdd_usage >= 0)
+            {
+                theApp.m_hdd_usage = hdd_usage;
+                m_hdd_usage_fail_cnt = 0;
             }
             else
             {
-                theApp.m_hdd_usage = -1;
+                m_hdd_usage_fail_cnt++;
+                if (m_hdd_usage_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+                    theApp.m_hdd_usage = -1;
             }
         }
+    }
+    else if (IsTemperatureNeeded() && theApp.m_pMonitor == nullptr)
+    {
+        // OpenHardwareMonitor 正在初始化中，增加所有失败计数器
+        m_gpu_temp_fail_cnt++;
+        m_gpu_usage_fail_cnt++;
+        m_cpu_temp_fail_cnt++;
+        m_hdd_temp_fail_cnt++;
+        m_mainboard_temp_fail_cnt++;
+        m_hdd_usage_fail_cnt++;
+        m_cpu_freq_fail_cnt++;
+
+        // 只有连续失败达到阈值才设为-1
+        if (m_gpu_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_gpu_temperature = -1;
+        if (m_gpu_usage_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_gpu_usage = -1;
+        if (m_cpu_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_cpu_temperature = -1;
+        if (m_hdd_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_hdd_temperature = -1;
+        if (m_mainboard_temp_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_main_board_temperature = -1;
+        if (m_hdd_usage_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_hdd_usage = -1;
+        if (m_cpu_freq_fail_cnt >= MAX_ITEM_FAIL_COUNT)
+            theApp.m_cpu_freq = -1;
     }
 #endif
 
@@ -2867,6 +3044,14 @@ LRESULT CTrafficMonitorDlg::OnDisplaychange(WPARAM wParam, LPARAM lParam)
 {
     GetScreenSize();
     CheckWindowPos(true);
+
+    // 分辨率变化后重新初始化任务栏窗口，防止任务栏窗口消失或崩溃
+    // 分辨率变化可能导致任务栏窗口句柄失效或位置计算错误
+    if (IsTaskbarWndValid())
+    {
+        CloseTaskBarWnd();
+        OpenTaskBarWnd();
+    }
     return 0;
 }
 

--- a/TrafficMonitor/TrafficMonitorDlg.h
+++ b/TrafficMonitor/TrafficMonitorDlg.h
@@ -134,6 +134,23 @@ protected:
     bool m_monitor_data_required{ false };          //线程中需要获取监控数据标志，当需要获取监控数据时置为true，获取到一次监控数据时置为false
     bool m_is_thread_exit{ false }; //线程退出标志
     CEvent m_threadExitEvent;       //用于通知主线程工作线程已退出
+
+#ifndef WITHOUT_TEMPERATURE
+    int m_hardware_monitor_error_cnt{ 0 };      //硬件监控连续错误计数
+    bool m_hardware_monitor_error_shown{ false };   //是否已经显示过硬件监控错误提示
+    bool m_hardware_monitor_disabled_by_error{ false };  //是否因连续错误而禁用了硬件监控
+    static const int MAX_HARDWARE_MONITOR_ERRORS = 5;    //连续错误达到此数值后自动禁用硬件监控
+
+    // 各监控项的连续失败计数器
+    int m_gpu_temp_fail_cnt{ 0 };       //显卡温度连续失败计数
+    int m_gpu_usage_fail_cnt{ 0 };      //显卡利用率连续失败计数
+    int m_cpu_temp_fail_cnt{ 0 };       //CPU温度连续失败计数
+    int m_hdd_temp_fail_cnt{ 0 };       //硬盘温度连续失败计数
+    int m_mainboard_temp_fail_cnt{ 0 }; //主板温度连续失败计数
+    int m_hdd_usage_fail_cnt{ 0 };      //硬盘利用率连续失败计数
+    int m_cpu_freq_fail_cnt{ 0 };       //CPU频率连续失败计数
+    static const int MAX_ITEM_FAIL_COUNT = 3;  //单项连续失败达到此数值后才显示"--"
+#endif
 public:
     void ExitMonitorThread();       //停止监控线程
 


### PR DESCRIPTION
## 问题背景

显卡温度、显卡利用率等硬件监控数据偶尔会出现获取失败的情况，原有逻辑每次获取失败都会立即显示"--"，导致界面频繁闪烁。

## 解决方案

采用指数退避策略：
- 为每个监控项添加独立的连续失败计数器
- 只有连续失败达到阈值（默认3次）才显示"--"
- 偶尔1-2次失败时保持上次有效值
- 成功获取后立即重置计数器

## 修改内容

- `TrafficMonitorDlg.h`: 添加各监控项的连续失败计数器
- `TrafficMonitorDlg.cpp`: 修改数据获取逻辑，移除每次预先重置为-1的做法
