### PR TITLE
加载插件时，最先调用插件的OnInitialize

### DIFF
--- a/TrafficMonitor/PluginManager.cpp
+++ b/TrafficMonitor/PluginManager.cpp
@@ -85,6 +85,13 @@ void CPluginManager::LoadPlugins()
             plugin_info.state = PluginState::PS_VERSION_NOT_SUPPORT;
             continue;
         }
+
+        //调用初始化函数
+        if (version >= 7)
+        {
+            plugin_info.plugin->OnInitialize(&theApp);
+        }
+
         //向插件传递配置文件的路径
         std::wstring config_dir = theApp.m_config_dir;
         config_dir += L"plugins\\";
@@ -92,12 +99,6 @@ void CPluginManager::LoadPlugins()
         {
             CreateDirectory(config_dir.c_str(), NULL);       //如果plugins不存在，则创建它
             plugin_info.plugin->OnExtenedInfo(ITMPlugin::EI_CONFIG_DIR, config_dir.c_str());
-        }
-
-        //调用初始化函数
-        if (version >= 7)
-        {
-            plugin_info.plugin->OnInitialize(&theApp);
         }
 
         //获取插件信息


### PR DESCRIPTION
按照语义OnInitialize()应该先于其他函数调用来初始化插件状态。

但是在TrafficMonitor (TM) 1.86版加载插件时，先调用OnExtenedInfo()后调用OnInitialize()。这不符合对OnInitialize()的预期，也不利于新版插件对旧版TM的兼容。