### PR TITLE
修复程序刚启动时不能自动调整任务栏窗口宽度的问题

### DIFF
--- a/TrafficMonitor/TaskBarDlg.cpp
+++ b/TrafficMonitor/TaskBarDlg.cpp
@@ -869,6 +869,9 @@ void CTaskBarDlg::CalculateWindowSize()
 
     int item_count = static_cast<int>(m_item_widths.size());
 
+    auto last_window_width{ m_window_width };
+    auto last_window_height{ m_window_height };
+
     //计算窗口总宽度
     if (IsTasksbarOnTopOrBottom())  //任务栏在桌面的顶部或底部时
     {
@@ -930,6 +933,12 @@ void CTaskBarDlg::CalculateWindowSize()
         m_window_height = TASKBAR_WND_HEIGHT / 2 * item_count;
         m_window_height += (DPI(theApp.m_taskbar_data.item_space) * item_count);   //加上每个标签间的空隙
     }
+
+    // 如果窗口尺寸发生变化，则重新调整任务栏窗口位置
+    if (last_window_width != m_window_width || last_window_height != m_window_height) {
+        WidthChanged();
+    }
+
     m_rect.right = m_rect.left + m_window_width;
     m_rect.bottom = m_rect.top + m_window_height;
 
@@ -1237,16 +1246,8 @@ void CTaskBarDlg::OnTimer(UINT_PTR nIDEvent)
             m_tool_tips.Pop();
         }
         
-        //每秒钟重新计算窗口的宽度，如果发生变化，则重新调整任务栏窗口位置
-        static int last_window_width = m_window_width;
-        static int last_window_height = m_window_height;
+        //每秒钟重新计算窗口的宽度
         CalculateWindowSize();
-        if (last_window_width != m_window_width || last_window_height != m_window_height)
-        {
-            WidthChanged();
-            last_window_width = m_window_width;
-            last_window_height = m_window_height;
-        }
     }
 
     CDialogEx::OnTimer(nIDEvent);


### PR DESCRIPTION
目前自动宽度调节代码存在一个潜在问题：

- 任务栏窗口初始化阶段，获取到了插件的初始宽度，并计算得到CTaskBarDlg::m_window_width，记为W1
- 插件开始运行，根据实际数据更新了自身宽度
- CTrafficMonitorDlg::OnTimer(TASKBAR_TIMER)先于CTaskBarDlg::OnTimer(TASKBAR_TIMER)执行，期间调用了CalculateWindowSize()函数重新计算了窗口宽度CTaskBarDlg::m_window_width，记为W2
- CTaskBarDlg::OnTimer(TASKBAR_TIMER)开始执行，先缓存CTaskBarDlg::m_window_width的值W2，后重新计算窗口宽度仍得到W2，所以不触发WidthChanged()

这导致程序刚启动时很可能感知不到宽度变化造成宽度不正确。

解决方案：

将检查宽度变化的逻辑放入CalculateWindowSize()函数，即时感知尺寸变化；CTaskBarDlg::OnTimer()只调用CalculateWindowSize()，不再缓存窗口尺寸。