### PR TITLE
修复通知区图标GDI句柄泄漏问题

### DIFF
--- a/TrafficMonitor/TrafficMonitorDlg.cpp
+++ b/TrafficMonitor/TrafficMonitorDlg.cpp
@@ -48,6 +48,17 @@ CTrafficMonitorDlg::~CTrafficMonitorDlg()
     }
 
     ::ReleaseDC(NULL, m_desktop_dc);
+
+    // Destroy notify area icon handles loaded via LoadImage in OnInitDialog
+    // LoadImage creates a copy of the icon resource; each must be freed with DestroyIcon
+    for (int i = 0; i < MAX_NOTIFY_ICON; i++)
+    {
+        if (theApp.m_notify_icons[i] != NULL)
+        {
+            ::DestroyIcon(theApp.m_notify_icons[i]);
+            theApp.m_notify_icons[i] = NULL;
+        }
+    }
 }
 
 CTaskBarDlg* CTrafficMonitorDlg::GetTaskbarWindow() const


### PR DESCRIPTION
OnInitDialog中通过LoadImage加载了6个通知区图标，但析构函数中从未
调用DestroyIcon释放这些图标句柄。LoadImage配合LR_CREATEDIBSECTION 创建的图标副本需要调用方负责销毁，否则每次程序运行都会泄漏6个GDI句柄。
在析构函数中添加循环逐一销毁非空的图标句柄并置NULL。